### PR TITLE
na_ontap_command - new features

### DIFF
--- a/ansible_collections/netapp/ontap/plugins/modules/na_ontap_command.py
+++ b/ansible_collections/netapp/ontap/plugins/modules/na_ontap_command.py
@@ -52,7 +52,7 @@ options:
         - applied only when return_dict is true
         - return only lines containing string pattern in stdout_lines_filter
         default: ''
-        version_added: "19.10.0"    
+        version_added: "19.10.0"
 '''
 
 EXAMPLES = """


### PR DESCRIPTION
##### SUMMARY

Adding _'stdout_lines_filter'_ list to dictionary output (`return_dict: true`) and two new module options:
- _exclude_lines_
- _include_lines_

stdout_lines_filter returns only lines that contains `<string>` defined in _include_lines_ and do not contain `<string>` defined in _exclude_lines_

This makes output parsing way easier:

```yaml
na_ontap_command:
        command: ["ldap", "client", "show", "-fields", "base-dn,ldap-servers"]
        exclude_lines: 'server '
```

```yaml
...
stdout_lines:
      - vserver    client-config    ldap-servers    base-dn
      - Vserver    Client Configuration Name    LDAP Server List    Base DN
      - svm1  client1    ldap.example.com    dc=example,dc=com
stdout_lines_filter:
      - svm1  client1    ldap.example.com    dc=example,dc=comm
...
```

```yaml
another_module:
      something: "{{ item }}"
loop: "{{ command_result.msg.stdout_lines_filter }}"

# rather than
another_module:
      something: "{{ item }}"
loop: "{{ command_result.msg.stdout_lines }}"
when:
      - not item is search("^Vserver")
      - not item is search("^vserver")
```

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
na_ontap_command 